### PR TITLE
Various cluster connection fixes

### DIFF
--- a/hazelcast/connection.py
+++ b/hazelcast/connection.py
@@ -1,8 +1,11 @@
 from __future__ import with_statement
+
 import logging
 import struct
+import sys
 import threading
 import time
+
 from hazelcast.config import PROPERTY_HEARTBEAT_INTERVAL, PROPERTY_HEARTBEAT_TIMEOUT
 from hazelcast.core import CLIENT_TYPE
 from hazelcast.exception import AuthenticationError
@@ -80,10 +83,8 @@ class ConnectionManager(object):
                                                                self._client.config.network_config.socket_options,
                                                                connection_closed_callback=self._connection_closed,
                                                                message_callback=self._client.invoker._handle_client_message)
-                    except IOError as io_error:
-                        logging.warning(io_error)
-                        return ImmediateExceptionFuture(io_error)
-                        # raise io_error
+                    except IOError:
+                        return ImmediateExceptionFuture(sys.exc_info()[1], sys.exc_info()[2])
 
                     future = authenticator(connection).continue_with(self.on_auth, connection, address)
                     if not future.done():

--- a/hazelcast/core.py
+++ b/hazelcast/core.py
@@ -12,7 +12,7 @@ class Member(object):
         self.attributes = attributes
 
     def __str__(self):
-        return "Member [{}]:{}".format(self.address.host, self.address.port)
+        return "Member [{}]:{} - {}".format(self.address.host, self.address.port, self.uuid)
 
     def __repr__(self):
         return "Member(host={}, port={}, uuid={}, liteMember={}, attributes={})" \

--- a/hazelcast/future.py
+++ b/hazelcast/future.py
@@ -149,6 +149,9 @@ class ImmediateFuture(Future):
     def exception(self):
         return None
 
+    def traceback(self):
+        return None
+
     def result(self):
         return self._result
 
@@ -157,10 +160,11 @@ class ImmediateFuture(Future):
 
 
 class ImmediateExceptionFuture(Future):
-    def __init__(self, exception):
+    def __init__(self, exception, traceback=None):
         self._exception = exception
+        self._traceback = traceback
 
-    def set_exception(self, exception):
+    def set_exception(self, exception, traceback=None):
         raise NotImplementedError()
 
     def set_result(self, result):
@@ -175,8 +179,11 @@ class ImmediateExceptionFuture(Future):
     def exception(self):
         return self._exception
 
+    def traceback(self):
+        return self._traceback
+
     def result(self):
-        return None
+        raise self._exception, None, self._traceback
 
     def add_done_callback(self, callback):
         self._invoke_cb(callback)

--- a/hazelcast/reactor.py
+++ b/hazelcast/reactor.py
@@ -81,7 +81,8 @@ class AsyncoreReactor(object):
         self._thread.join()
 
     def new_connection(self, address, connect_timeout, socket_options, connection_closed_callback, message_callback):
-        return AsyncoreConnection(self._map, address, connect_timeout, socket_options, connection_closed_callback, message_callback)
+        return AsyncoreConnection(self._map, address, connect_timeout, socket_options, connection_closed_callback,
+                                  message_callback)
 
     def _cleanup_timer(self, timer):
         try:
@@ -112,7 +113,10 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
             self.socket.setsockopt(socket_option.level, socket_option.option, socket_option.value)
 
         self.connect(self._address)
-        self.socket.settimeout(None)
+
+        # the socket should be non-blocking from now on
+        self.socket.settimeout(0)
+
         self._write_queue.append("CB2")
 
     def handle_connect(self):

--- a/tests/reconnect_test.py
+++ b/tests/reconnect_test.py
@@ -31,11 +31,15 @@ class ReconnectTest(HazelcastTestCase):
 
     def test_start_client_before_member(self):
         Thread(target=self.cluster.start_member).start()
-        self.create_client()
+        config = ClientConfig()
+        config.network_config.connection_attempt_limit = 10
+        self.create_client(config)
 
     def test_restart_member(self):
         member = self.cluster.start_member()
-        client = self.create_client()
+        config = ClientConfig()
+        config.network_config.connection_attempt_limit = 10
+        client = self.create_client(config)
 
         state = [None]
 
@@ -77,7 +81,9 @@ class ReconnectTest(HazelcastTestCase):
 
     def test_member_list_after_reconnect(self):
         old_member = self.cluster.start_member()
-        client = self.create_client()
+        config = ClientConfig()
+        config.network_config.connection_attempt_limit = 10
+        client = self.create_client(config)
         old_member.shutdown()
 
         new_member = self.cluster.start_member()


### PR DESCRIPTION
- Fix .result() in ImmediateExceptionFuture and add tests for the class
- connection should be set to non-blocking after initial connection
- Member list should be cleared when owner connection is closed to prevent reconnect loop
- Improved exception handling for serialization service (should not print to stdout)
